### PR TITLE
chore: move to commercetools namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jest-enzyme-matchers",
+  "name": "@commercetools/jest-enzyme-matchers",
   "version": "1.0.0",
   "description": "Enzyme specific jest matchers",
   "main": "dist/index.js",


### PR DESCRIPTION
After merge:
- [x] deprecate `jest-enzyme-matchers`
- [ ] publish `@commercetools/jest-enzyme-matchers`