### PR TITLE
Add `toContainClass` matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools/jest-enzyme-matchers",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Enzyme specific jest matchers",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ const getComponentName = element => typeof element === 'string'
 const isWrapper = wrapper => Boolean(wrapper && wrapper.debug && wrapper.find)
 
 export function toRender (wrapper, element) {
-  // check that received is actually a wrapper
   if (!isWrapper(wrapper)) {
     const matcherHint = this.isNot ? '.not.toRender' : '.toRender'
     return {
@@ -42,7 +41,6 @@ export function toRender (wrapper, element) {
 }
 
 export function toRenderElementTimes (wrapper, element, times) {
-  // check that received is actually a wrapper
   if (!isWrapper(wrapper)) {
     const matcherHint = this.isNot
       ? '.not.toRenderElementTimes'
@@ -79,7 +77,6 @@ export function toRenderElementTimes (wrapper, element, times) {
 }
 
 export function toContainClass (wrapper, className) {
-  // check that received is actually a wrapper
   if (!isWrapper(wrapper)) {
     const matcherHint = this.isNot ? '.not.toContainClass' : '.toContainClass'
     return {

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export function toRender (wrapper, element) {
   const message = pass
     ? () => stripIndent`
       ${this.utils.matcherHint('.not.toRender')}\n
-        Expected wrapper to not render:
+        Expected wrapper not to render:
           ${this.utils.printExpected(componentName)}
         Received:
           ${this.utils.printReceived(wrapper.debug())}`
@@ -64,7 +64,7 @@ export function toRenderElementTimes (wrapper, element, times) {
   const message = pass
     ? () => stripIndent`
       ${this.utils.matcherHint('.not.toRenderElementTimes')}\n
-        Expected wrapper to not render ${componentString} ${timeString} times.
+        Expected wrapper not to render ${componentString} ${timeString} times.
         It was rendered ${this.utils.printReceived(actualTimes)} times:
           ${this.utils.printReceived(wrapper.debug())}`
     : () => stripIndent`
@@ -95,7 +95,7 @@ export function toContainClass (element, className) {
   const message = pass
     ? () => stripIndent`
       ${this.utils.matcherHint('.not.toContainClass')}\n
-        Expected element to not contain class:
+        Expected element not to contain class:
           ${this.utils.printExpected(componentName)}
         Received:
           ${this.utils.printReceived(element.debug())}`

--- a/src/index.js
+++ b/src/index.js
@@ -77,3 +77,37 @@ export function toRenderElementTimes (wrapper, element, times) {
 
   return { actual: wrapper, message, pass }
 }
+
+export function toContainClass (wrapper, className) {
+  // check that received is actually a wrapper
+  if (!isWrapper(wrapper)) {
+    const matcherHint = this.isNot ? '.not.toContainClass' : '.toContainClass'
+    return {
+      pass: this.isNot,
+      message: stripIndent`
+        ${this.utils.matcherHint(matcherHint)}\n
+          Argument passed to expect() must be an enzyme wrapper.
+          Received:
+            ${this.utils.printReceived(wrapper)}`,
+    }
+  }
+
+  const pass = wrapper.hasClass(className)
+  const componentName = getComponentName(wrapper)
+
+  const message = pass
+    ? () => stripIndent`
+      ${this.utils.matcherHint('.not.toContainClass')}\n
+        Expected wrapper to not render:
+          ${this.utils.printExpected(componentName)}
+        Received:
+          ${this.utils.printReceived(wrapper.debug())}`
+    : () => stripIndent`
+      ${this.utils.matcherHint('.toContainClass')}\n
+        Expected value to render:
+          ${this.utils.printExpected(componentName)}
+        Received:
+          ${this.utils.printReceived(wrapper.debug())}`
+
+  return { actual: wrapper, message, pass }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -76,35 +76,35 @@ export function toRenderElementTimes (wrapper, element, times) {
   return { actual: wrapper, message, pass }
 }
 
-export function toContainClass (wrapper, className) {
-  if (!isWrapper(wrapper)) {
+export function toContainClass (element, className) {
+  if (!isWrapper(element)) {
     const matcherHint = this.isNot ? '.not.toContainClass' : '.toContainClass'
     return {
       pass: this.isNot,
       message: stripIndent`
         ${this.utils.matcherHint(matcherHint)}\n
-          Argument passed to expect() must be an enzyme wrapper.
+          Argument passed to expect() must be an enzyme element.
           Received:
-            ${this.utils.printReceived(wrapper)}`,
+            ${this.utils.printReceived(element)}`,
     }
   }
 
-  const pass = wrapper.hasClass(className)
-  const componentName = getComponentName(wrapper)
+  const pass = element.hasClass(className)
+  const componentName = getComponentName(element)
 
   const message = pass
     ? () => stripIndent`
       ${this.utils.matcherHint('.not.toContainClass')}\n
-        Expected wrapper to not render:
+        Expected element to not contain class:
           ${this.utils.printExpected(componentName)}
         Received:
-          ${this.utils.printReceived(wrapper.debug())}`
+          ${this.utils.printReceived(element.debug())}`
     : () => stripIndent`
       ${this.utils.matcherHint('.toContainClass')}\n
-        Expected value to render:
+        Expected value to contain class:
           ${this.utils.printExpected(componentName)}
         Received:
-          ${this.utils.printReceived(wrapper.debug())}`
+          ${this.utils.printReceived(element.debug())}`
 
-  return { actual: wrapper, message, pass }
+  return { actual: element, message, pass }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
 import stripIndent from 'common-tags/lib/stripIndent'
 import getDisplayName from 'react-display-name'
 
+const getComponentName = element => typeof element === 'string'
+  ? element
+  : getDisplayName(element)
+
+const isWrapper = wrapper => wrapper && wrapper.debug && wrapper.find
+
 export function toRender (wrapper, element) {
   // check that received is actually a wrapper
-  if (!wrapper || !wrapper.debug || !wrapper.find) {
+  if (!isWrapper(wrapper)) {
     const matcherHint = this.isNot ? '.not.toRender' : '.toRender'
     return {
       pass: this.isNot,
@@ -16,9 +22,7 @@ export function toRender (wrapper, element) {
   }
 
   const pass = wrapper.find(element).length > 0
-  const componentName = typeof element === 'string'
-    ? element
-    : getDisplayName(element)
+  const componentName = getComponentName(element)
 
   const message = pass
     ? () => stripIndent`
@@ -39,7 +43,7 @@ export function toRender (wrapper, element) {
 
 export function toRenderElementTimes (wrapper, element, times) {
   // check that received is actually a wrapper
-  if (!wrapper || !wrapper.debug || !wrapper.find) {
+  if (!isWrapper(wrapper)) {
     const matcherHint = this.isNot
       ? '.not.toRenderElementTimes'
       : '.toRenderElementTimes'
@@ -55,9 +59,7 @@ export function toRenderElementTimes (wrapper, element, times) {
 
   const actualTimes = wrapper.find(element).length
   const pass = actualTimes === times
-  const componentName = typeof element === 'string'
-    ? element
-    : getDisplayName(element)
+  const componentName = getComponentName(element)
 
   const componentString = this.utils.printExpected(componentName)
   const timeString = this.utils.printExpected(times)

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const getComponentName = element => typeof element === 'string'
   ? element
   : getDisplayName(element)
 
-const isWrapper = wrapper => wrapper && wrapper.debug && wrapper.find
+const isWrapper = wrapper => Boolean(wrapper && wrapper.debug && wrapper.find)
 
 export function toRender (wrapper, element) {
   // check that received is actually a wrapper


### PR DESCRIPTION
Adds a `toContainClass` based on [`hasClass`](https://github.com/airbnb/enzyme/blob/master/docs/api/ReactWrapper/hasClass.md) matcher and extract commonly used things just a little bit.

```js
expect(wrapper).toContainClass('foo')
expect(wrapper).not.toContainClass('bar')
```